### PR TITLE
Owning reference to a string with O(1) access to lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.1.4 (2020-03-04)
+
+- Added `CachedLines`
+
 ## Version 0.1.3 (2021-08-25)
 
 - Added default `alloc` feature, and made the crate `#![no_std]`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line-span"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Christian Vallentin"]
 edition = "2018"
 description = "Find line ranges and jump between next and previous lines"


### PR DESCRIPTION
This can be useful if you have a string that you don't want to modify but do want to access line by line in a random order.